### PR TITLE
fix: 🐛 Correct the input parameters for CA related SQ calls

### DIFF
--- a/src/api/entities/confidential/ConfidentialAccount/index.ts
+++ b/src/api/entities/confidential/ConfidentialAccount/index.ts
@@ -1,6 +1,7 @@
 import { AugmentedQueries } from '@polkadot/api/types';
 import { ConfidentialAssetsElgamalCipherText } from '@polkadot/types/lookup';
 import type { Option, U8aFixed } from '@polkadot/types-codec';
+import { hexStripPrefix } from '@polkadot/util';
 import BigNumber from 'bignumber.js';
 
 import {
@@ -268,7 +269,9 @@ export class ConfidentialAccount extends Entity<UniqueIdentifiers, string> {
       confidentialAssetsByHolderQuery(publicKey, size, start)
     );
 
-    const data = nodes.map(({ assetId: id }) => new ConfidentialAsset({ id }, context));
+    const data = nodes.map(
+      ({ assetId: id }) => new ConfidentialAsset({ id: hexStripPrefix(id) }, context)
+    );
     const count = new BigNumber(totalCount);
     const next = calculateNextKey(count, data.length, start);
 

--- a/src/api/entities/confidential/ConfidentialAsset/index.ts
+++ b/src/api/entities/confidential/ConfidentialAsset/index.ts
@@ -364,7 +364,7 @@ export class ConfidentialAsset extends Entity<UniqueIdentifiers, string> {
     } = await context.queryMiddleware<Ensured<Query, 'confidentialAssetHistories'>>(
       transactionHistoryByConfidentialAssetQuery(
         {
-          assetId: id.toString(),
+          assetId: serializeConfidentialAssetId(id),
         },
         size,
         start
@@ -401,7 +401,7 @@ export class ConfidentialAsset extends Entity<UniqueIdentifiers, string> {
       },
     } = await context.queryMiddleware<Ensured<Query, 'confidentialAssets'>>(
       confidentialAssetQuery({
-        id,
+        id: serializeConfidentialAssetId(id),
       })
     );
 

--- a/src/api/entities/confidential/__tests__/ConfidentialAsset/index.ts
+++ b/src/api/entities/confidential/__tests__/ConfidentialAsset/index.ts
@@ -463,7 +463,7 @@ describe('ConfidentialAsset class', () => {
       dsMockUtils.createApolloQueryMock(
         transactionHistoryByConfidentialAssetQuery(
           {
-            assetId: confidentialAsset.toHuman(),
+            assetId: `0x${assetId}`,
           },
           new BigNumber(2),
           new BigNumber(0)
@@ -490,7 +490,7 @@ describe('ConfidentialAsset class', () => {
 
       dsMockUtils.createApolloQueryMock(
         transactionHistoryByConfidentialAssetQuery({
-          assetId: confidentialAsset.toHuman(),
+          assetId: `0x${assetId}`,
         }),
         {
           confidentialAssetHistories: confidentialAssetHistoriesResponse,
@@ -511,7 +511,7 @@ describe('ConfidentialAsset class', () => {
       const blockHash = 'someHash';
       const eventIdx = new BigNumber(1);
       const variables = {
-        id,
+        id: `0x${assetId}`,
       };
       const fakeResult = { blockNumber, blockHash, blockDate, eventIndex: eventIdx };
 
@@ -537,7 +537,7 @@ describe('ConfidentialAsset class', () => {
 
     it('should return null if the query result is empty', async () => {
       const variables = {
-        id,
+        id: `0x${assetId}`,
       };
 
       dsMockUtils.createApolloQueryMock(confidentialAssetQuery(variables), {

--- a/src/middleware/queries/confidential.ts
+++ b/src/middleware/queries/confidential.ts
@@ -25,7 +25,7 @@ export function confidentialAssetsByHolderQuery(
   const query = gql`
     query ConfidentialAssetsByAccount($size: Int, $start: Int, $accountId: String!) {
       confidentialAssetHolders(
-        accountId: { equalTo: $accountId }
+        filter: { accountId: { equalTo: $accountId } }
         orderBy: [${ConfidentialAssetHoldersOrderBy.CreatedBlockIdAsc}]
         first: $size
         offset: $start


### PR DESCRIPTION
### Description

Fixes the calls made to CA SQ. Currently the calls were not serializing the asset ID in hex prefix ID that is understood by SQ. Also, a query was written incorrectly in one of the methods.

### Breaking Changes

NA

### JIRA Link

NA

### Checklist

- [ ] Updated the Readme.md (if required) ?
